### PR TITLE
Add support for no delimiters in offset

### DIFF
--- a/src/Iso8601.elm
+++ b/src/Iso8601.elm
@@ -327,6 +327,7 @@ iso8601 =
                             ]
                         -- SSS
                         |= utcOffsetInMinutes
+                        |. end
                     , succeed (fromParts datePart 0 0 0 0 0)
                         |. end
                     ]
@@ -336,14 +337,10 @@ iso8601 =
 utcOffsetInMinutes : Parser Int
 utcOffsetInMinutes =
     let
-        offsetInMinutes : Int -> Int -> Int
-        offsetInMinutes hours minutes =
-            (hours * 60) + minutes
-
-        utcOffsetMinutesFromParts : Int -> Int -> Int
-        utcOffsetMinutesFromParts multiplier calculatedOffset =
+        utcOffsetMinutesFromParts : Int -> Int -> Int -> Int
+        utcOffsetMinutesFromParts multiplier hours minutes =
             -- multiplier is either 1 or -1 (for negative UTC offsets)
-            multiplier * calculatedOffset
+            multiplier * (hours * 60) + minutes
     in
     Parser.succeed identity
         |= oneOf
@@ -357,17 +354,13 @@ utcOffsetInMinutes =
                     , map (\_ -> -1) (symbol "-")
                     ]
                 -- support 01, 0100 and 01:00
+                |= paddedInt 2
                 |= oneOf
-                    [ succeed offsetInMinutes
-                        |= paddedInt 2
-                        |= succeed 0
-                    , succeed offsetInMinutes
-                        |= paddedInt 2
-                        |= paddedInt 2
-                    , succeed offsetInMinutes
-                        |= paddedInt 2
+                    [ succeed identity
                         |. symbol ":"
                         |= paddedInt 2
+                    , paddedInt 2
+                    , succeed 0
                     ]
             ]
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -78,6 +78,10 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+01"
                     |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
+        , test "toTime fails on invalid offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130546"
+                    |> Expect.err
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -70,6 +70,18 @@ knownValues =
             \_ ->
                 Iso8601.toTime "2080831T232516Z"
                     |> Expect.err
+        , test "toTime supports no delimiter in offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352673000000))
+        , test "toTime supports offset with only hours" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+01"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
+        , test "toTime fails on invalid offset" <|
+            \_ ->
+                Iso8601.toTime "2012-11-12T00:00:00+0130546"
+                    |> Expect.err
         ]
 
 

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -72,16 +72,12 @@ knownValues =
                     |> Expect.err
         , test "toTime supports no delimiter in offset" <|
             \_ ->
-                Iso8601.toTime "2012-11-12T00:00:00+0130"
-                    |> Expect.equal (Ok (Time.millisToPosix 1352673000000))
+                Iso8601.toTime "2012-11-12T00:00:00+0100"
+                    |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
         , test "toTime supports offset with only hours" <|
             \_ ->
                 Iso8601.toTime "2012-11-12T00:00:00+01"
                     |> Expect.equal (Ok (Time.millisToPosix 1352674800000))
-        , test "toTime fails on invalid offset" <|
-            \_ ->
-                Iso8601.toTime "2012-11-12T00:00:00+0130546"
-                    |> Expect.err
         ]
 
 


### PR DESCRIPTION
You say in the PR to rtfeldman tha it fixes https://github.com/rtfeldman/elm-iso8601-date-strings/issues/13 but your PR does not address delimiters in the offset, only in the rest of the ISO 8601 string.

This fixes that. :smile: 
This also add support for offset by hour only which is part of the standard.

Would you like to merge it in here and get it as part of your PR or should I create a new PR to Richards repo?

I have a temporary package for use until this gets in to Richards original package: https://package.elm-lang.org/packages/ringvold/elm-iso8601-date-strings/latest/

